### PR TITLE
Tuning for Too many open connections

### DIFF
--- a/src/main/resources/applicationContext-resources.xml
+++ b/src/main/resources/applicationContext-resources.xml
@@ -30,7 +30,7 @@
 	<bean id="dataSource" class="com.mchange.v2.c3p0.ComboPooledDataSource"
 		destroy-method="close">
 		<property name="driverClass" value="com.mysql.jdbc.Driver" />
-		<property name="jdbcUrl" value="jdbc:mysql://localhost:3306/transys" />
+		<property name="jdbcUrl" value="jdbc:mysql://localhost:3306/transys?autoReconnect=true" />
 		<property name="user" value="root"/>
 	    <property name="password" value=""/>	
 	    <property name="initialPoolSize" value="20"/>
@@ -38,7 +38,7 @@
 	    <property name="maxPoolSize" value="500"/>
 	    <property name="acquireIncrement" value="5"/><!-- Determines how many connections at a time c3p0 will try to acquire when the pool is exhausted -->
 	    <property name="maxStatementsPerConnection" value="0" /><!-- The size of c3p0's PreparedStatement cache. Zero means statement caching is turned off. -->
-	    <property name="maxIdleTime" value="1000" />
+	    <property name="maxIdleTime" value="28800" />
 	    <property name="preferredTestQuery" value="SELECT 1;" />
 	    <property name="idleConnectionTestPeriod" value="60" />
 	    <property name="maxConnectionAge" value="14400" /><!-- To recreate connection after 4 hrs in order to prevent socket closing by DB server -->


### PR DESCRIPTION
Also execute the following command in the MySQL Server:

1) currently the wait_timeout is set to 8 hours. Set it to a higher value
set @@global.wait_timeout=31536000;

Ref: https://coderanch.com/t/562063/databases/Data-source-rejected-establishment-connection
